### PR TITLE
Removed duplicate "name" key

### DIFF
--- a/tasks/font.yml
+++ b/tasks/font.yml
@@ -4,8 +4,7 @@
     - libfreetype6-dev
     - libfontconfig
   name: 'Wkhtmltox | Fonts | install packages'
-- name: 'Accept License'
-  shell: 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections'
+- shell: 'echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections'
   name: 'Wkhtmltox | Fonts | Accept MScorefonts EULA'
 - apt: pkg=ttf-mscorefonts-installer
   name: 'Wkhtmltox | Fonts | Install MS Corefonts'


### PR DESCRIPTION
This fixes the following warning I get when running this in a vagrant machine with ansible 2.2.1.0:

```
[WARNING]: While constructing a mapping from
/vagrant/ansible/roles/zealot128.wkhtmltox/tasks/font.yml, line 7, column 3,
found a duplicate dict key (name). Using last defined value only.
```